### PR TITLE
Version bump action refactor

### DIFF
--- a/packages/version-bump/action.yml
+++ b/packages/version-bump/action.yml
@@ -7,6 +7,8 @@ inputs:
         description: 'The version bump type i.e. `major` | `minor` | `patch` | `release_type` | `build`'
     value:
         description: 'The value to use for bumping. Usually used to set release type or reset build.'
+    release-type:
+        description: 'Explicit value for setting the release type while bumping the version.'
     main-file:
         required: true
         description: 'Path of the plugin main file'

--- a/packages/version-bump/src/tests/main.test.ts
+++ b/packages/version-bump/src/tests/main.test.ts
@@ -10,6 +10,7 @@ const input = {
 	'readme-file': 'readme.txt',
 	type: 'minor',
 	value: null,
+	'release-type': null,
 };
 let output: Record<string, string> = {};
 
@@ -49,10 +50,11 @@ describe('version bump main tests', () => {
 	it('returns the expected output for a given input', async () => {
 		checkForDuplicateCases(mainNormalTestCases);
 
-		for (const { type, inputVer, outputVer, value } of mainNormalTestCases) {
+		for (const { type, inputVer, outputVer, releaseType, value } of mainNormalTestCases) {
 			// set bump type
 			input.type = type;
 			input.value = value;
+			input['release-type'] = releaseType;
 			// set mock to dynamically generate input file
 			const contentMock = jest.spyOn(io, 'readFileSync').mockImplementation((path) => {
 				return getMockedFileContents(path as string, inputVer);

--- a/packages/version-bump/src/tests/utils.ts
+++ b/packages/version-bump/src/tests/utils.ts
@@ -1,4 +1,4 @@
-import { BumpType } from '../utils';
+import { BumpType, ReleaseType } from '../utils';
 
 export const getMockedFileContents = (path: string, version?: string): string => {
 	switch (path) {
@@ -32,6 +32,7 @@ type MainTestCase = {
 	type: BumpType;
 	inputVer: string;
 	outputVer: string;
+	releaseType?: ReleaseType;
 	value?: string;
 };
 
@@ -85,14 +86,28 @@ export const mainNormalTestCases: Array<MainTestCase> = [
 	{
 		type: 'major',
 		inputVer: '0.0.0',
-		outputVer: '1.0.0.rc',
+		outputVer: '1.0.0',
 	},
 	{
 		type: 'major',
 		inputVer: '0.0.0',
-		outputVer: '5.0.0.rc',
+		outputVer: '5.0.0',
 		// explicitly set the version
 		value: '5',
+	},
+	{
+		type: 'major',
+		inputVer: '0.0.0',
+		outputVer: '1.0.0.beta',
+		// explicitly set the release type, when there is none
+		releaseType: 'beta',
+	},
+	{
+		type: 'major',
+		inputVer: '4.0.0.beta',
+		outputVer: '5.0.0.rc',
+		// explicitly set the release type, when there is already one
+		releaseType: 'rc',
 	},
 	{
 		type: 'minor',
@@ -119,14 +134,28 @@ export const mainNormalTestCases: Array<MainTestCase> = [
 	{
 		type: 'minor',
 		inputVer: '0.0.0',
-		outputVer: '0.1.0.rc',
+		outputVer: '0.1.0',
 	},
 	{
 		type: 'minor',
 		inputVer: '5.3.1',
-		outputVer: '5.5.0.rc',
+		outputVer: '5.5.0',
 		// explicitly set the version
 		value: '5',
+	},
+	{
+		type: 'minor',
+		inputVer: '0.0.0',
+		outputVer: '0.1.0.beta',
+		// explicitly set the release type, when there is none
+		releaseType: 'beta',
+	},
+	{
+		type: 'minor',
+		inputVer: '4.4.0.beta',
+		outputVer: '4.5.0.rc',
+		// explicitly set the release type, when there is already one
+		releaseType: 'rc',
 	},
 	{
 		type: 'patch',
@@ -150,7 +179,7 @@ export const mainNormalTestCases: Array<MainTestCase> = [
 		type: 'patch',
 		inputVer: '0.0.0',
 		// patch shoud be incremented
-		outputVer: '0.0.1.rc',
+		outputVer: '0.0.1',
 	},
 	{
 		type: 'patch',
@@ -161,9 +190,23 @@ export const mainNormalTestCases: Array<MainTestCase> = [
 	{
 		type: 'patch',
 		inputVer: '1.0.6',
-		outputVer: '1.0.5.rc',
+		outputVer: '1.0.5',
 		// explicitly set the version
 		value: '5',
+	},
+	{
+		type: 'patch',
+		inputVer: '0.0.0',
+		outputVer: '0.0.1.beta',
+		// explicitly set the release type, when there is none
+		releaseType: 'beta',
+	},
+	{
+		type: 'patch',
+		inputVer: '4.0.3.beta',
+		outputVer: '4.0.4.rc',
+		// explicitly set the release type, when there is already one
+		releaseType: 'rc',
 	},
 	{
 		type: 'release_type',

--- a/packages/version-bump/src/utils.ts
+++ b/packages/version-bump/src/utils.ts
@@ -9,11 +9,14 @@ export interface Input {
 	infoJsonFile: string;
 	mainFile: string;
 	readmeFile: string;
+	releaseType?: ReleaseType;
 	value?: string;
 	type: BumpType;
 }
 
 export const bumpTypes: Array<BumpType> = ['major', 'minor', 'patch', 'release_type', 'build'];
+
+export const releaseTypes: Array<ReleaseType> = ['alpha', 'beta', 'decaf', 'rc', 'p'];
 
 /**
  * Retrieve the action inputs.
@@ -24,6 +27,7 @@ export function getInput(): Input {
 	const readmeFile = core.getInput('readme-file', { required: true });
 	const type = core.getInput('type', { required: true }) as BumpType;
 	const value = core.getInput('value');
+	const releaseType = core.getInput('release-type') as ReleaseType;
 
 	if (!io.existsSync(mainFile)) {
 		throw new Error('Main file does not exist.');
@@ -37,11 +41,15 @@ export function getInput(): Input {
 	if (!bumpTypes.includes(type)) {
 		throw new Error(`Unknown bump type - ${type}`);
 	}
+	if (releaseType && !releaseTypes.includes(releaseType)) {
+		throw new Error(`Unknown release type - ${releaseType}`);
+	}
 
 	return {
 		infoJsonFile,
 		mainFile,
 		readmeFile,
+		releaseType,
 		type,
 		value,
 	};
@@ -58,23 +66,21 @@ export const README_FILE_STABLE_TAG_REGEX = /[\s\t/*#@]*Stable tag:\s*(?<stable_
 /**
  * The regex reperesenting the version schema used by EE.
  *
- * MAJOR    ([0-9]+)                 MUST match & capture a number
- * DOT      \.                       MUST match a period
- * MINOR    ([0-9]+)                 MUST match & capture a number
- * DOT      \.                       MUST match a period
- * PATCH    ([0-9]+)                 MUST match & capture a number
- * DOT      \.?                      maybe match a period
- * RELEASE  (alpha|beta|rc|p|decaf)* maybe match one of values in brackets
- * DOT      \.?                      maybe match a period
- * BUILD    ([0-9]*)                 maybe match & capture a number
+ * MAJOR    ([0-9]+)                  MUST match & capture a number
+ * DOT      \.                        MUST match a period
+ * MINOR    ([0-9]+)                  MUST match & capture a number
+ * DOT      \.                        MUST match a period
+ * PATCH    ([0-9]+)                  MUST match & capture a number
+ * RELEASE  \.(alpha|beta|rc|p|decaf) optionally match a dot and one of values in brackets
+ * BUILD    \.([0-9]*)                optionally match a dot & capture a number
  * @see: https://regex101.com/r/5nSgf3/1/
  */
-export const EE_VERSION_REGEX = /^(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)\.?(?<releaseType>alpha|beta|rc|p|decaf)*\.?(?<build>[0-9]*)$/;
+export const EE_VERSION_REGEX = /^(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)(?:\.(?<releaseType>alpha|beta|rc|p|decaf))?(?:\.(?<build>[0-9]*))?$/;
 
 export const DEFAULT_VERSION_PARTS = {
 	major: 0,
 	minor: 0,
 	patch: 0,
-	releaseType: 'rc',
+	releaseType: '',
 	build: 0,
 };


### PR DESCRIPTION
This PR adds an explicit `release-type` option to version bump action to avoid automatically adding release type when not intended, as mentioned in [this comment](https://github.com/eventespresso/actions/pull/8#discussion_r525309912).