### PR TITLE
Implement Cache Versioning

### DIFF
--- a/packages/checkout-and-yarn/action.yml
+++ b/packages/checkout-and-yarn/action.yml
@@ -4,7 +4,7 @@ author: 'eventespresso'
 inputs:
     cache-version:
         required: false
-        description: 'used for refreshing the cache, value doesn't matter as long as it changes when you need a refresh'
+        description: 'used for refreshing the cache by simply changing value to something new'
         default: '1'
     fetch-depth:
         required: false

--- a/packages/checkout-and-yarn/action.yml
+++ b/packages/checkout-and-yarn/action.yml
@@ -2,6 +2,10 @@ name: 'Checkout and run yarn'
 description: 'This action checks out the commit, sets up Node and installs deps using yarn.'
 author: 'eventespresso'
 inputs:
+    cache-version:
+        required: false
+        description: 'used for refreshing the cache, value doesn't matter as long as it changes when you need a refresh'
+        default: '1'
     fetch-depth:
         required: false
         description: 'Number of commits to fetch during checkout. 0 indicates all history for all branches and tags.'
@@ -29,7 +33,7 @@ runs:
           uses: actions/cache@v2
           with:
               path: '**/node_modules'
-              key: ${{ runner.os }}-modules-${{ secrets.GH_ACTIONS_CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+              key: ${{ runner.os }}-modules-${{ inputs.cache-version }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Install dependencies
           # install deps only if lockfile has changed

--- a/packages/checkout-and-yarn/action.yml
+++ b/packages/checkout-and-yarn/action.yml
@@ -29,7 +29,7 @@ runs:
           uses: actions/cache@v2
           with:
               path: '**/node_modules'
-              key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+              key: ${{ runner.os }}-modules-${{ secrets.GH_ACTIONS_CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Install dependencies
           # install deps only if lockfile has changed


### PR DESCRIPTION
been having problems with cached dependencies while working on the auto-pr-labeler, so this PR adds the organization secret `GH_ACTIONS_CACHE_VERSION`  to the cache key used in `packages/checkout-and-yarn/action.yml`

the current value for that secret is 1, but can be bumped at anytime in order to flush the cache and build new dependencies.