### PR TITLE
Assign Support Staff to PR after Review Approved

### DIFF
--- a/packages/auto-pr-labeler/src/assignLabels.ts
+++ b/packages/auto-pr-labeler/src/assignLabels.ts
@@ -21,7 +21,7 @@ import type { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types';
  *
  * @param assignableId ID
  * @param assigneeIds [ID]
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<AssigneesQueryResponse>>
  */
 const addAssignees = async (
 	assignableId: ID,
@@ -41,11 +41,12 @@ const addAssignees = async (
  *
  * @param assignableId ID
  * @param assigneeIds [ID]
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<AssigneesQueryResponse>>
  */
 const addAssigneesAfterReviewApproved = async (
 	assignableId: ID
 ): Promise<GraphQlQueryResponse<AssigneesQueryResponse>> => {
+	// filter out any staff who are not Q/A then return array of IDs
 	const supportStaff = espressoStaff.filter((staff) => staff.support).map((support) => support.id);
 	return await addAssignees(assignableId, supportStaff);
 };

--- a/packages/auto-pr-labeler/src/assignLabels.ts
+++ b/packages/auto-pr-labeler/src/assignLabels.ts
@@ -40,7 +40,6 @@ const addAssignees = async (
  * assigns Q/A staff to the specified Pull Request
  *
  * @param assignableId ID
- * @param assigneeIds [ID]
  * @returns Promise<GraphQlQueryResponse<AssigneesQueryResponse>>
  */
 const addAssigneesAfterReviewApproved = async (

--- a/packages/auto-pr-labeler/src/espressoStaff.ts
+++ b/packages/auto-pr-labeler/src/espressoStaff.ts
@@ -1,0 +1,58 @@
+import type { Staff } from './types';
+
+export const espressoStaff: Staff[] = [
+	{
+		login: 'knazart',
+		id: 'MDQ6VXNlcjEwNDg1NjE=',
+		dev: true,
+		support: false,
+	},
+	{
+		login: 'tn3rb',
+		id: 'MDQ6VXNlcjE3NTEwMzA=',
+		dev: true,
+		support: false,
+	},
+	{
+		login: 'garthkoyle',
+		id: 'MDQ6VXNlcjMwOTQ1NDc=',
+		dev: false,
+		support: true,
+	},
+	{
+		login: 'eeteamcodebase',
+		id: 'MDQ6VXNlcjMwOTg1OTE=',
+		dev: false,
+		support: false,
+	},
+	{
+		login: 'alexkuc',
+		id: 'MDQ6VXNlcjMzMzE5NDY=',
+		dev: true,
+		support: false,
+	},
+	{
+		login: 'Pebblo',
+		id: 'MDQ6VXNlcjQzNDU0MTc=',
+		dev: false,
+		support: true,
+	},
+	{
+		login: 'hoseinrafiei',
+		id: 'MDQ6VXNlcjI5MTQ0NTQy',
+		dev: true,
+		support: false,
+	},
+	{
+		login: 'kingrio13',
+		id: 'MDQ6VXNlcjMxNDY0MTI5',
+		dev: false,
+		support: true,
+	},
+	{
+		login: 'Saam01',
+		id: 'U_kgDOBfWk5g',
+		dev: false,
+		support: true,
+	},
+];

--- a/packages/auto-pr-labeler/src/mutations.ts
+++ b/packages/auto-pr-labeler/src/mutations.ts
@@ -3,7 +3,29 @@ import type { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types';
 
 import { gqlVariables } from './utils';
 
-import type { ID, LabelsQueryResponse } from './types';
+import type { AssigneesQueryResponse, ID, LabelsQueryResponse } from './types';
+
+export const addAssigneesMutation = async (
+	assignableId: ID,
+	assigneeIds: Array<ID>
+): Promise<GraphQlQueryResponse<AssigneesQueryResponse>> => {
+	return await graphql(
+		`
+			mutation ($assignableId: ID!, $assigneeIds: [ID!]!) {
+				addAssigneesToAssignable(input: { assignableId: $assignableId, assigneeIds: $assigneeIds }) {
+					assignable {
+						assignees(first: 10) {
+							nodes {
+								login
+							}
+						}
+					}
+				}
+			}
+		`,
+		{ assigneeIds, assignableId, ...gqlVariables }
+	);
+};
 
 export const addLabelsMutation = async (
 	labelIds: Array<ID>,
@@ -38,6 +60,7 @@ export const removeLabelsMutation = async (
 					labelable {
 						labels(first: 10) {
 							nodes {
+								id
 								name
 							}
 						}

--- a/packages/auto-pr-labeler/src/types.ts
+++ b/packages/auto-pr-labeler/src/types.ts
@@ -3,6 +3,10 @@ import { PR_REVIEW_DECISION, PR_STATE } from './constants';
 export type ID = string | number;
 export type RepoName = string;
 
+export interface AssigneesQueryResponse {
+	assignees: User[];
+}
+
 export interface Issue {
 	assignees: UserConnection;
 	id: ID;
@@ -65,7 +69,14 @@ export interface PullRequestQueryResponse {
 	};
 }
 
-interface User {
+export interface Staff {
+	id: ID;
+	login: string;
+	dev: boolean;
+	support: boolean;
+}
+
+export interface User {
 	id: ID;
 	login: string;
 }


### PR DESCRIPTION
This PR:

- adds new `AssigneesQueryResponse` & `Staff` interfaces
- adds new `addAssigneesMutation` mutation
- adds new `espressoStaff` array
- adds new `addAssignees()` & `addAssigneesAfterReviewApproved()` functions
- calls `addAssigneesAfterReviewApproved()` when code reviews are approved which assigns support staff to PR
- also applies "Needs Testing" label to PR 