### PR TITLE
Apply Labels from Other Repo in assignHasFixLabel()

### DIFF
--- a/packages/auto-pr-labeler/src/assignLabels.ts
+++ b/packages/auto-pr-labeler/src/assignLabels.ts
@@ -55,7 +55,7 @@ const addAssigneesAfterReviewApproved = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const addLabels = async (
 	labelIds: Array<ID>,
@@ -97,13 +97,13 @@ const hasLabel = (pullRequest: PullRequest, labelableId: ID): boolean => {
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignHasFixLabel = async (
 	labels: LabelList,
 	otherRepoLabels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	await removeAllStatusLabels(labels, labelableId, labels.statusNeedsTesting.id);
 	const added = await addLabels([labels.statusHasFix.id], labelableId);
 	// label might be for the other repo, so if the above does not return false, return it
@@ -119,12 +119,12 @@ const assignHasFixLabel = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterClose = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusInvalid.id], labelableId);
 };
 
@@ -133,12 +133,12 @@ const assignLabelsAfterClose = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterMerge = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusCompleted.id], labelableId);
 };
 
@@ -147,12 +147,12 @@ const assignLabelsAfterMerge = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterCreated = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusNew.id], labelableId);
 };
 
@@ -161,12 +161,12 @@ const assignLabelsAfterCreated = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterReviewApproved = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusApproved.id, labels.statusNeedsTesting.id], labelableId);
 };
 
@@ -175,12 +175,12 @@ const assignLabelsAfterReviewApproved = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterReviewChangesRequested = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusPleaseFix.id], labelableId);
 };
 
@@ -189,12 +189,12 @@ const assignLabelsAfterReviewChangesRequested = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterReviewRequested = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusCodeReview.id], labelableId);
 };
 
@@ -203,12 +203,12 @@ const assignLabelsAfterReviewRequested = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const assignLabelsAfterReviewRequestRemoved = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	return await addLabels([labels.statusInProgress.id], labelableId);
 };
 
@@ -218,13 +218,13 @@ const assignLabelsAfterReviewRequestRemoved = async (
  * @param labels LabelList
  * @param labelableId ID
  * @param except ID 		ID of a label to exclude from removal
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 const removeAllStatusLabels = async (
 	labels: LabelList,
 	labelableId: ID,
 	except: ID = ''
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	try {
 		let labelIds: Array<ID> = [
 			labels.statusNew.id,
@@ -258,7 +258,7 @@ const removeAllStatusLabels = async (
  * loops through any related closing Issues and assigns the `has fix` label
  *
  * @param closingIssues IssueConnection
- * @param repoLabels RepoLabels
+ * @param repo RepoName
  */
 export const assignLabelsToClosingIssues = async (closingIssues: IssueConnection, repo: RepoName) => {
 	// eslint-disable-next-line no-console
@@ -280,13 +280,13 @@ export const assignLabelsToClosingIssues = async (closingIssues: IssueConnection
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 export const assignLabelsToOpenPullRequests = async (
 	labels: LabelList,
 	pullRequest: PullRequest,
 	repo: RepoName
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | false> => {
 	await assignLabelsToClosingIssues(pullRequest.closingIssuesReferences, repo);
 	// for OPEN PRs, let's first look whether a code review has either been requested or received a response
 	// see: https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision
@@ -321,12 +321,12 @@ export const assignLabelsToOpenPullRequests = async (
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 export const assignLabelsToClosedPullRequests = async (
 	labels: LabelList,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	if (pullRequest.reviewDecision === PR_REVIEW_DECISION.APPROVED) {
 		await removeAllStatusLabels(labels, pullRequest.id, labels.statusCompleted.id);
 		return await assignLabelsAfterMerge(labels, pullRequest.id);
@@ -340,12 +340,12 @@ export const assignLabelsToClosedPullRequests = async (
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | false>
  */
 export const assignLabelsToMergedPullRequests = async (
 	labels: LabelList,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	await removeAllStatusLabels(labels, pullRequest.id, labels.statusCompleted.id);
 	return await assignLabelsAfterMerge(labels, pullRequest.id);
 };
@@ -355,12 +355,12 @@ export const assignLabelsToMergedPullRequests = async (
  *
  * @param repo: RepoName
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | string>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | false>
  */
 export const assignStatusLabels = async (
 	repo: RepoName,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | boolean> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | false> => {
 	try {
 		// eslint-disable-next-line no-console
 		console.log('%c pullRequest.state', 'color: HotPink;', pullRequest.state);

--- a/packages/auto-pr-labeler/src/assignLabels.ts
+++ b/packages/auto-pr-labeler/src/assignLabels.ts
@@ -55,15 +55,19 @@ const addAssigneesAfterReviewApproved = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
-const addLabels = async (labelIds: Array<ID>, labelableId: ID): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+const addLabels = async (
+	labelIds: Array<ID>,
+	labelableId: ID
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | false> => {
 	try {
 		// eslint-disable-next-line no-console
 		console.log('%c labelMutation', 'color: HotPink;', { labelableId, labelIds });
 		return await addLabelsMutation(labelIds, labelableId);
 	} catch (error) {
 		core.setFailed(error.message);
+		return false;
 	}
 };
 
@@ -86,18 +90,28 @@ const hasLabel = (pullRequest: PullRequest, labelableId: ID): boolean => {
 };
 
 /**
- * adds the `has fix` label to the specified Issue
+ * adds the `has fix` label to the specified Issue,
+ * since it's possible that the Issue is in the other repo
+ * we first try the label from the same issue as the PR
+ * if that fails, we try the label from the other repo
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignHasFixLabel = async (
 	labels: LabelList,
+	otherRepoLabels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	await removeAllStatusLabels(labels, labelableId, labels.statusNeedsTesting.id);
-	return await addLabels([labels.statusHasFix.id], labelableId);
+	const added = await addLabels([labels.statusHasFix.id], labelableId);
+	// label might be for the other repo, so if the above does not return false, return it
+	if (added !== false) {
+		return added;
+	}
+	// otherwise try the other repo's label
+	return await addLabels([otherRepoLabels.statusHasFix.id], labelableId);
 };
 
 /**
@@ -105,12 +119,12 @@ const assignHasFixLabel = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterClose = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusInvalid.id], labelableId);
 };
 
@@ -119,12 +133,12 @@ const assignLabelsAfterClose = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterMerge = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusCompleted.id], labelableId);
 };
 
@@ -133,12 +147,12 @@ const assignLabelsAfterMerge = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterCreated = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusNew.id], labelableId);
 };
 
@@ -147,12 +161,12 @@ const assignLabelsAfterCreated = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterReviewApproved = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusApproved.id, labels.statusNeedsTesting.id], labelableId);
 };
 
@@ -161,12 +175,12 @@ const assignLabelsAfterReviewApproved = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterReviewChangesRequested = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusPleaseFix.id], labelableId);
 };
 
@@ -175,12 +189,12 @@ const assignLabelsAfterReviewChangesRequested = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterReviewRequested = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusCodeReview.id], labelableId);
 };
 
@@ -189,12 +203,12 @@ const assignLabelsAfterReviewRequested = async (
  *
  * @param labels LabelList
  * @param labelableId ID
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const assignLabelsAfterReviewRequestRemoved = async (
 	labels: LabelList,
 	labelableId: ID
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	return await addLabels([labels.statusInProgress.id], labelableId);
 };
 
@@ -204,13 +218,13 @@ const assignLabelsAfterReviewRequestRemoved = async (
  * @param labels LabelList
  * @param labelableId ID
  * @param except ID 		ID of a label to exclude from removal
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 const removeAllStatusLabels = async (
 	labels: LabelList,
 	labelableId: ID,
 	except: ID = ''
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	try {
 		let labelIds: Array<ID> = [
 			labels.statusNew.id,
@@ -244,17 +258,19 @@ const removeAllStatusLabels = async (
  * loops through any related closing Issues and assigns the `has fix` label
  *
  * @param closingIssues IssueConnection
- * @param labels LabelList
+ * @param repoLabels RepoLabels
  */
-export const assignLabelsToClosingIssues = async (closingIssues: IssueConnection, labels: LabelList) => {
+export const assignLabelsToClosingIssues = async (closingIssues: IssueConnection, repo: RepoName) => {
 	// eslint-disable-next-line no-console
 	console.log('%c assignLabelsToClosingIssues', 'color: HotPink;', closingIssues);
 	if (closingIssues.totalCount > 0) {
 		const issues = closingIssues.nodes;
+		const labels = repoLabels[repo];
+		const otherRepoLabels = repoLabels[repo === 'barista' ? 'cafe' : 'barista'];
 		for (const issue of issues) {
 			// eslint-disable-next-line no-console
 			console.log('%c  closing Issue', 'color: DeepPink;', issue);
-			await assignHasFixLabel(labels, issue?.id);
+			await assignHasFixLabel(labels, otherRepoLabels, issue?.id);
 		}
 	}
 };
@@ -264,13 +280,14 @@ export const assignLabelsToClosingIssues = async (closingIssues: IssueConnection
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 export const assignLabelsToOpenPullRequests = async (
 	labels: LabelList,
-	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string> => {
-	await assignLabelsToClosingIssues(pullRequest.closingIssuesReferences, labels);
+	pullRequest: PullRequest,
+	repo: RepoName
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | boolean> => {
+	await assignLabelsToClosingIssues(pullRequest.closingIssuesReferences, repo);
 	// for OPEN PRs, let's first look whether a code review has either been requested or received a response
 	// see: https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision
 	switch (pullRequest.reviewDecision) {
@@ -304,12 +321,12 @@ export const assignLabelsToOpenPullRequests = async (
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 export const assignLabelsToClosedPullRequests = async (
 	labels: LabelList,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	if (pullRequest.reviewDecision === PR_REVIEW_DECISION.APPROVED) {
 		await removeAllStatusLabels(labels, pullRequest.id, labels.statusCompleted.id);
 		return await assignLabelsAfterMerge(labels, pullRequest.id);
@@ -323,12 +340,12 @@ export const assignLabelsToClosedPullRequests = async (
  *
  * @param labels LabelList
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean>
  */
 export const assignLabelsToMergedPullRequests = async (
 	labels: LabelList,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse>> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | boolean> => {
 	await removeAllStatusLabels(labels, pullRequest.id, labels.statusCompleted.id);
 	return await assignLabelsAfterMerge(labels, pullRequest.id);
 };
@@ -338,12 +355,12 @@ export const assignLabelsToMergedPullRequests = async (
  *
  * @param repo: RepoName
  * @param pullRequest: PullRequest
- * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse>>
+ * @returns Promise<GraphQlQueryResponse<LabelsQueryResponse> | string>
  */
 export const assignStatusLabels = async (
 	repo: RepoName,
 	pullRequest: PullRequest
-): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string> => {
+): Promise<GraphQlQueryResponse<LabelsQueryResponse> | string | boolean> => {
 	try {
 		// eslint-disable-next-line no-console
 		console.log('%c pullRequest.state', 'color: HotPink;', pullRequest.state);
@@ -354,7 +371,7 @@ export const assignStatusLabels = async (
 		console.log('%c repoLabels', 'color: DeepPink;', labels);
 		switch (pullRequest.state) {
 			case PR_STATE.OPEN:
-				return await assignLabelsToOpenPullRequests(labels, pullRequest);
+				return await assignLabelsToOpenPullRequests(labels, pullRequest, repo);
 			case PR_STATE.CLOSED:
 				return await assignLabelsToClosedPullRequests(labels, pullRequest);
 			case PR_STATE.MERGED:


### PR DESCRIPTION
After making changes to https://github.com/eventespresso/barista/pull/1251
the Auto PR Labeler workflow ran but encountered the following error:
https://github.com/eventespresso/barista/actions/runs/6397687054/job/17366172149?pr=1251

![image](https://github.com/eventespresso/actions/assets/1751030/50e26f99-4698-47c3-aeed-db9475f16837)

which happened because PR 1251 references an issue from cafe via "closing text" in the original post:

> Fixes https://github.com/eventespresso/cafe/issues/816

and we are trying to apply the "has fix" label to that issue.

The error arises because the Auto PR Labeler action was initially set up with the assumption that all labels would belong to the same repo. But since Barista PR 1251 references Cafe Issue 816, we can't apply the Barista Has Fix label, and instead need to apply the Cafe Has Fix label.

This PR attempts to fix this by applying the other repo's label if the first attempt fails.
There's probably a more smarterer way to do this, but this was fastest to implement.