### PR TITLE
Minor update for package e2e-tests

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -10,6 +10,10 @@ This action makes it trivial to run end-to-end tests for Event Espresso product 
 | `barista_repo_branch`   | Which branch to use for Barista repository?   | string  |          |
 | `e2e_tests_repo_branch` | Which branch to use for E2E Tests repository? | string  |    \*    |
 | `skip_tests`            | Should E2E tests be skipped?                  | boolean |          |
+| `e2e_gpg_password`      | Password used to encrypt Playwright artifacts | string  |   \*\*   |
+| `gpg_cipher`            | Type of cipher to be used for GPG encryption  | string  |          |
+
+\*\* Without a password, Playwright artifacts will not be uploaded to prevent exposure of sensitive information but it will _not_ prevent test runner from completing successfully
 
 ## Example Workflow File
 
@@ -41,4 +45,6 @@ jobs:
                   cafe_repo_branch: DEV
                   barista_repo_branch: master
                   e2e_tests_repo_branch: master
+                  e2e_gpg_password: ${{ secrets.E2E_GPG_PASSWORD }}
+                  gpg_cipher: AES256
 ```

--- a/packages/e2e-tests/action.yml
+++ b/packages/e2e-tests/action.yml
@@ -18,7 +18,7 @@ inputs:
         type: boolean
         required: false
         default: false
-    gpg_password:
+    e2e_gpg_password: # prefixed with e2e_ since org level secret
         description: This value will be used to encrypt artifacts
         type: string
         required: false

--- a/packages/e2e-tests/src/InputFactory.ts
+++ b/packages/e2e-tests/src/InputFactory.ts
@@ -18,7 +18,7 @@ class InputFactory {
 	}
 
 	public gpgPassword(): string {
-		return core.getInput('gpg_password', { required: false });
+		return core.getInput('e2e_gpg_password', { required: false });
 	}
 
 	public gpgCipher(): string {


### PR DESCRIPTION
Rename of input `gpg_password` to `e2e_gpg_password` to account for organization-level naming. Also, update of `README.md`.