### PR TITLE
Fix barista plugin not being activated in E2E tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,6 @@
 		"**/lib": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.organizeImports": false
+		"source.organizeImports": "never"
 	}
 }

--- a/packages/e2e-tests/src/Action.ts
+++ b/packages/e2e-tests/src/Action.ts
@@ -3,7 +3,6 @@ import { InputFactory } from './InputFactory';
 import { ContextFactory } from './ContextFactory';
 import { Context } from './Context';
 import * as core from '@actions/core';
-import { env } from 'node:process';
 import { Browsers } from './Browsers';
 
 class Action {
@@ -58,7 +57,8 @@ class Action {
 
 	private getEnvVars(cafe: Context, barista: Context): EnvVars {
 		const vars: EnvVars = { CAFE: cafe.cwd };
-		if (env['BARISTA']) {
+		const baristaBranch = this.inputs.baristaBranch();
+		if (baristaBranch.length > 0) {
 			vars.BARISTA = barista.cwd;
 		}
 		return vars;


### PR DESCRIPTION
This fixes a bug where barista plugin activation is skipped (erroneously)