### PR TITLE
Allow to pin the version of DDEV used by E2E package

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -4,14 +4,15 @@ This action makes it trivial to run end-to-end tests for Event Espresso product 
 
 ## Input
 
-| Name                    | Description                                   | Type    | Required |
-| ----------------------- | --------------------------------------------- | ------- | :------: |
-| `cafe_repo_branch`      | Which branch to use for Cafe repository?      | string  |    \*    |
-| `barista_repo_branch`   | Which branch to use for Barista repository?   | string  |          |
-| `e2e_tests_repo_branch` | Which branch to use for E2E Tests repository? | string  |    \*    |
-| `skip_tests`            | Should E2E tests be skipped?                  | boolean |          |
-| `gpg_password`          | Password used to encrypt Playwright artifacts | string  |   \*\*   |
-| `gpg_cipher`            | Type of cipher to be used for GPG encryption  | string  |          |
+| Name                    | Description                                              | Type    | Required |
+| ----------------------- | -------------------------------------------------------- | ------- | :------: |
+| `cafe_repo_branch`      | Which branch to use for Cafe repository?                 | string  |    \*    |
+| `barista_repo_branch`   | Which branch to use for Barista repository?              | string  |          |
+| `e2e_tests_repo_branch` | Which branch to use for E2E Tests repository?            | string  |    \*    |
+| `skip_tests`            | Should E2E tests be skipped?                             | boolean |          |
+| `gpg_password`          | Password used to encrypt Playwright artifacts            | string  |   \*\*   |
+| `gpg_cipher`            | Type of cipher to be used for GPG encryption             | string  |          |
+| `ddev_version`          | Which version of DDEV to use? Defaults to latest version | string  |          |
 
 \*\* Without a password, Playwright artifacts will not be uploaded to prevent exposure of sensitive information but it will _not_ prevent test runner from completing successfully
 

--- a/packages/e2e-tests/action.yml
+++ b/packages/e2e-tests/action.yml
@@ -28,6 +28,10 @@ inputs:
         type: string
         required: false
         default: AES256
+    ddev_version:
+        description: Which version of DDEV to use?
+        type: string
+        required: false
 runs:
     using: node16
     main: dist/index.js

--- a/packages/e2e-tests/src/Action.ts
+++ b/packages/e2e-tests/src/Action.ts
@@ -49,10 +49,24 @@ class Action {
 		this.spawnSync.call('sudo', ['apt-get', 'install', '--yes', 'libnss3-tools', 'mkcert']);
 	}
 
+	private getDdevVersion(): string | undefined {
+		const version = this.inputs.ddevVersion();
+		if (!version) {
+			return;
+		}
+		return 'v' + version;
+	}
+
 	private ddev(): void {
 		core.info('Installing DDEV');
 		const curl = this.spawnSync.call('curl', ['-fsSL', 'https://ddev.com/install.sh'], { stdout: 'pipe' });
-		this.spawnSync.call('bash', [], { stdin: 'pipe', input: curl.stdout });
+		const bashArgs: string[] = [];
+		const ddevVersion = this.getDdevVersion();
+		if (ddevVersion) {
+			bashArgs.push('-s');
+			bashArgs.push(ddevVersion);
+		}
+		this.spawnSync.call('bash', bashArgs, { stdin: 'pipe', input: curl.stdout });
 	}
 
 	private getEnvVars(cafe: Context, barista: Context): EnvVars {

--- a/packages/e2e-tests/src/InputFactory.ts
+++ b/packages/e2e-tests/src/InputFactory.ts
@@ -24,6 +24,19 @@ class InputFactory {
 	public gpgCipher(): string {
 		return core.getInput('gpg_cipher', { required: false });
 	}
+
+	public ddevVersion(): string | undefined {
+		const version = core.getInput('ddev_version', { required: false });
+		if (!version) {
+			return; // "Returns an empty string if the value is not defined."
+		}
+		const pattern = /([^\d\.]+)/;
+		const regex = new RegExp(pattern);
+		if (regex.test(version)) {
+			throw new Error('Use of wrong format for DDEV version!');
+		}
+		return version;
+	}
 }
 
 export { InputFactory };

--- a/packages/e2e-tests/src/InputFactory.ts
+++ b/packages/e2e-tests/src/InputFactory.ts
@@ -30,7 +30,7 @@ class InputFactory {
 		if (!version) {
 			return; // "Returns an empty string if the value is not defined."
 		}
-		const pattern = /([^\d\.]+)/;
+		const pattern = /([^\d.]+)/;
 		const regex = new RegExp(pattern);
 		if (regex.test(version)) {
 			throw new Error('Use of wrong format for DDEV version!');


### PR DESCRIPTION
For reasons yet to be established [ddev](https://ddev.com/) version `1.22.7` completely fails on GitHub CI while `1.22.6` runs perfectly fine. As a quick workaround, I am adding support for version pinning.