### PR TITLE
Improve logging in e2e package

### DIFF
--- a/packages/e2e-tests/src/Action.ts
+++ b/packages/e2e-tests/src/Action.ts
@@ -53,7 +53,7 @@ class Action {
 		const repos: InstanceType<typeof Repository>[] = contexts.map((context) => {
 			return context.repo;
 		});
-		core.summary.addHeading('Git information');
+		core.summary.addHeading('Git information', 2);
 		core.summary.addTable([
 			[
 				{ data: 'Repo', header: true },

--- a/packages/e2e-tests/src/Action.ts
+++ b/packages/e2e-tests/src/Action.ts
@@ -2,8 +2,8 @@ import { SpawnSync } from './SpawnSync';
 import { InputFactory } from './InputFactory';
 import { ContextFactory } from './ContextFactory';
 import { Context } from './Context';
-import * as core from '@actions/core';
 import { Browsers } from './Browsers';
+import { log } from './utilities';
 
 class Action {
 	private readonly browsers: Browsers;
@@ -45,7 +45,7 @@ class Action {
 	}
 
 	private mkcert(): void {
-		core.info('Installing mkcert');
+		log('Installing mkcert...');
 		this.spawnSync.call('sudo', ['apt-get', 'install', '--yes', 'libnss3-tools', 'mkcert']);
 	}
 
@@ -58,7 +58,7 @@ class Action {
 	}
 
 	private ddev(): void {
-		core.info('Installing DDEV');
+		log('Installing DDEV...');
 		const curl = this.spawnSync.call('curl', ['-fsSL', 'https://ddev.com/install.sh'], { stdout: 'pipe' });
 		const bashArgs: string[] = [];
 		const ddevVersion = this.getDdevVersion();

--- a/packages/e2e-tests/src/Artifact.ts
+++ b/packages/e2e-tests/src/Artifact.ts
@@ -71,7 +71,13 @@ class Artifact {
 		const absInput = arrInput.map((i) => this.absPath(i, workDir));
 		const promises = absInput.map((i) => this.inputToFiles(i));
 		const files = await Promise.all(promises);
-		return files.flat();
+		return files.flat().filter((file) => {
+			const exists = fs.existsSync(file);
+			if (!exists) {
+				error('Given artifact file does not exist: ' + file);
+			}
+			return exists;
+		});
 	}
 
 	/**

--- a/packages/e2e-tests/src/Artifact.ts
+++ b/packages/e2e-tests/src/Artifact.ts
@@ -1,8 +1,9 @@
-import * as path from 'node:path';
-import * as core from '@actions/core';
+import { error } from './utilities';
 import * as glob from '@actions/glob';
 import * as artifact from '@actions/artifact';
 import type { ArtifactClient, UploadOptions } from '@actions/artifact';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 class Artifact {
 	private readonly client: ArtifactClient;
@@ -28,9 +29,7 @@ class Artifact {
 		const options: UploadOptions = { continueOnError: true, retentionDays: days };
 
 		if (files.length === 0) {
-			core.notice(
-				`Cannot save '${this.inputToStr(input)}' from the directory '${workDir}' as the directory is empty`
-			);
+			error(`Cannot save '${this.inputToStr(input)}' from the directory '${workDir}' as the directory is empty`);
 			return false;
 		}
 
@@ -38,15 +37,13 @@ class Artifact {
 
 		try {
 			upload = await this.client.uploadArtifact(name, files, workDir, options);
-		} catch (error) {
-			core.error(`Failed to save artifact '${name}', see below for details`);
-			core.error(`${error}`);
+		} catch (err) {
+			error('Failed to save artifact: ' + name, 'Error: ' + err);
 			return false;
 		}
 
 		if (upload.failedItems.length > 0) {
-			const failed = upload.failedItems.join('\n');
-			core.error(`Failied to upload some files for artifact '${name}':\n${failed}`);
+			error('Failed to upload some files for artifact', 'Artifact: ' + name, 'Files:', ...upload.failedItems);
 			return false;
 		}
 

--- a/packages/e2e-tests/src/Cache.ts
+++ b/packages/e2e-tests/src/Cache.ts
@@ -1,6 +1,5 @@
 import { Repository } from './Repository';
 import { error, annotation } from './utilities';
-import * as core from '@actions/core';
 import * as cache from '@actions/cache';
 
 class Cache {
@@ -47,9 +46,8 @@ class Cache {
 		const k = `repo-${this.repo.name}-${this.repo.branch}-${key}`;
 		const limit = 512; // https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action
 		if (k.length > limit) {
-			const message = `Cache key exceeded length of ${limit} chars: ` + k;
-			annotation(message);
-			throw new Error(message);
+			annotation(`Cache key exceeded length of ${limit} chars: ` + k);
+			throw new Error();
 		}
 		return k;
 	}

--- a/packages/e2e-tests/src/Cache.ts
+++ b/packages/e2e-tests/src/Cache.ts
@@ -1,11 +1,12 @@
+import { Repository } from './Repository';
+import { error, notice } from './utilities';
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
-import { Repository } from './Repository';
 
 class Cache {
 	constructor(private readonly repo: Repository) {
 		if (!cache.isFeatureAvailable()) {
-			core.error('Cache service is not available');
+			error('Cache service is not available');
 		}
 	}
 
@@ -18,8 +19,8 @@ class Cache {
 			// .slice() is a required workaround until GitHub fixes cache
 			// https://github.com/actions/toolkit/issues/1377
 			return await cache.saveCache(paths.slice(), k);
-		} catch (error) {
-			core.error(`Failed to save cache with key: \n${k}\n${error}`);
+		} catch (err) {
+			error('Failed to save cache with key:' + k, 'Error: ' + `${err}`);
 			return false;
 		}
 	}
@@ -31,11 +32,11 @@ class Cache {
 			// .slice() is a required workaround until GitHub fixes cache
 			// https://github.com/actions/toolkit/issues/1377
 			restore = await cache.restoreCache(paths.slice(), k);
-		} catch (error) {
-			core.error(`${error}`);
+		} catch (err) {
+			error(`${err}`);
 		}
 		if (typeof restore === 'undefined') {
-			core.notice(`Failed to retrieve cache with key: \n${k}`);
+			notice(`Failed to retrieve cache with key: \n${k}`);
 			return false;
 		}
 		return true;

--- a/packages/e2e-tests/src/Cache.ts
+++ b/packages/e2e-tests/src/Cache.ts
@@ -1,5 +1,5 @@
 import { Repository } from './Repository';
-import { error } from './utilities';
+import { error, notice } from './utilities';
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
 
@@ -45,10 +45,11 @@ class Cache {
 	private makeKey(key: string): string {
 		// generate contextual key since we are dealing with multiple repositories
 		const k = `repo-${this.repo.name}-${this.repo.branch}-${key}`;
-		if (k.length > 512) {
-			// https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action
-			const msg = `Cache key exceeded length of 512 chars: \n${k}`;
-			core.setFailed(msg);
+		const limit = 512; // https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action
+		if (k.length > limit) {
+			const message = `Cache key exceeded length of ${limit} chars: ` + k;
+			notice(message);
+			throw new Error(message);
 		}
 		return k;
 	}

--- a/packages/e2e-tests/src/Cache.ts
+++ b/packages/e2e-tests/src/Cache.ts
@@ -1,5 +1,5 @@
 import { Repository } from './Repository';
-import { error, notice } from './utilities';
+import { error } from './utilities';
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
 
@@ -36,7 +36,7 @@ class Cache {
 			error(`${err}`);
 		}
 		if (typeof restore === 'undefined') {
-			notice(`Failed to retrieve cache with key: \n${k}`);
+			error(`Failed to retrieve cache with key: \n${k}`);
 			return false;
 		}
 		return true;

--- a/packages/e2e-tests/src/Cache.ts
+++ b/packages/e2e-tests/src/Cache.ts
@@ -1,5 +1,5 @@
 import { Repository } from './Repository';
-import { error, notice } from './utilities';
+import { error, annotation } from './utilities';
 import * as core from '@actions/core';
 import * as cache from '@actions/cache';
 
@@ -48,7 +48,7 @@ class Cache {
 		const limit = 512; // https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#input-parameters-for-the-cache-action
 		if (k.length > limit) {
 			const message = `Cache key exceeded length of ${limit} chars: ` + k;
-			notice(message);
+			annotation(message);
 			throw new Error(message);
 		}
 		return k;

--- a/packages/e2e-tests/src/Context.ts
+++ b/packages/e2e-tests/src/Context.ts
@@ -1,10 +1,9 @@
-import { IOType } from 'child_process';
 import { Cache } from './Cache';
 import { SpawnSync, ExecSyncInterface } from './SpawnSync';
 import { Git } from './Git';
 import { Repository } from './Repository';
 import { Yarn } from './Yarn';
-import type { SpawnSyncOptions, ProcessEnvOptions, SpawnSyncReturns } from 'child_process';
+import type { SpawnSyncOptions, ProcessEnvOptions, SpawnSyncReturns, IOType } from 'child_process';
 
 class Context implements ExecSyncInterface {
 	private readonly spawnSync: SpawnSync;

--- a/packages/e2e-tests/src/Docker.ts
+++ b/packages/e2e-tests/src/Docker.ts
@@ -1,5 +1,5 @@
 import { SpawnSync } from './SpawnSync';
-import { error, log, notice } from './utilities';
+import { error, log } from './utilities';
 import * as cache from '@actions/cache';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
@@ -41,7 +41,7 @@ class Docker {
 			return false;
 		}
 		if (!restore) {
-			notice('No cache found for docker images');
+			error('No cache found for docker images');
 			return false;
 		}
 		this.spawnSync.call('docker', ['load', '--input', filePath]);

--- a/packages/e2e-tests/src/GPG.ts
+++ b/packages/e2e-tests/src/GPG.ts
@@ -1,13 +1,10 @@
 import { InputFactory } from './InputFactory';
+import { absPath, command, error, errorForSpawnSync, log } from './utilities';
+import zxcvbn from 'zxcvbn';
 import child_process, { type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
 import fs from 'node:fs';
-import zxcvbn from 'zxcvbn';
-import * as core from '@actions/core';
-import { absPath, command, logSpawnSyncError } from './utilities';
 
 class GPG {
-	private readonly groupName: string = 'GPG';
-
 	constructor(private readonly inputs: InputFactory) {}
 
 	private isInstalled(): boolean {
@@ -38,10 +35,7 @@ class GPG {
 		const output = target ? absPath(target) : input.replace('.gpg', '');
 
 		if (fs.existsSync(output)) {
-			core.startGroup(this.groupName);
-			core.error('Cannot decrypt GPG file in-place!');
-			core.error(`Output path already exists: '${output}' !`);
-			core.endGroup();
+			error('Cannot decrypt GPG file in-place!', 'Output path already exists!', 'File path: ' + output);
 			return false;
 		}
 
@@ -50,11 +44,10 @@ class GPG {
 		const options: SpawnSyncOptionsWithStringEncoding = { stdio: 'pipe', input: password, encoding: 'utf-8' };
 
 		const command = child_process.spawnSync('gpg', args, options);
-		console.log(command.stdout);
+		log(command.stdout);
 
 		if (command.status !== 0) {
-			const message = `Failed to decrypt GPG file: '${input}' !`;
-			logSpawnSyncError({ command, message, group: this.groupName });
+			errorForSpawnSync(command, 'Failed to decrypt GPG file!', 'File path: ' + input);
 			return false;
 		}
 
@@ -107,11 +100,12 @@ class GPG {
 
 		const command = child_process.spawnSync('gpg', args, options);
 
-		console.log(command.stdout);
+		if (command.status === 0) {
+			log(command.stdout);
+		}
 
 		if (command.status !== 0) {
-			const message = 'GPG encryption has failed!';
-			logSpawnSyncError({ command, message, group: this.groupName });
+			errorForSpawnSync(command, 'GPG encryption has failed!', 'File path: ' + source);
 			return false;
 		}
 
@@ -121,11 +115,7 @@ class GPG {
 	private getPath(input: string): string | false {
 		const p = absPath(input);
 		if (!this.checkPath(p)) {
-			core.startGroup(this.groupName);
-			core.error('Given input path does not exist!');
-			core.error('Raw input: ' + input);
-			core.error('Absolute path: ' + p);
-			core.endGroup();
+			error('Given input path does not exist!', 'Absolute path: ' + p);
 			return false;
 		}
 		return p;
@@ -133,9 +123,7 @@ class GPG {
 
 	private checkPath(path: string): boolean {
 		if (!fs.existsSync(path)) {
-			core.startGroup(this.groupName);
-			core.error(`Given path does not exist: '${path}' !`);
-			core.endGroup();
+			error('Given path does not exist!', 'File path: ' + path);
 			return false;
 		}
 		return true;
@@ -145,19 +133,14 @@ class GPG {
 		const password = this.inputs.gpgPassword();
 
 		if (password.length === 0) {
-			core.startGroup(this.groupName);
-			core.error(`Missing value for input 'password' !`);
-			core.endGroup();
+			error(`Missing value for input 'password' !`);
 			return false;
 		}
 
 		const strength = zxcvbn(password);
 
 		if (strength.score < 3) {
-			core.startGroup(this.groupName);
-			strength.feedback.suggestions.forEach((s) => core.notice(s));
-			core.warning(strength.feedback.warning);
-			core.endGroup();
+			error(strength.feedback.warning, ...strength.feedback.suggestions);
 			return false;
 		}
 
@@ -173,10 +156,7 @@ class GPG {
 		}
 
 		if (!supportedCiphers.includes(targetCipher)) {
-			core.startGroup(this.groupName);
-			core.error(`Unsupported GPG cipher: ${targetCipher}`);
-			core.notice(`Supported GPG ciphers: ${supportedCiphers.join(', ')}`);
-			core.endGroup();
+			error(`Unsupported GPG cipher: ${targetCipher}`, `Supported GPG ciphers: ${supportedCiphers.join(', ')}`);
 			return false;
 		}
 
@@ -186,11 +166,12 @@ class GPG {
 	private getSupportedCiphers(): string[] | false {
 		const command = child_process.spawnSync('gpg', ['--version'], { stdio: 'pipe', encoding: 'utf-8' });
 
-		console.log(command.stdout);
+		if (command.status === 0) {
+			log(command.stdout);
+		}
 
 		if (command.status !== 0) {
-			const message = 'Failed to get available GPG ciphers!';
-			logSpawnSyncError({ command, message, group: this.groupName });
+			errorForSpawnSync(command, 'Failed to get available GPG ciphers!');
 			return false;
 		}
 
@@ -199,9 +180,7 @@ class GPG {
 		const ciphersIndex = stdoutArray.findIndex((s) => s.startsWith('Cipher: '));
 
 		if (!stdoutArray[ciphersIndex] || !stdoutArray[ciphersIndex + 1]) {
-			core.startGroup(this.groupName);
-			core.error('Internal error! Unable to parse available GPG ciphers! (array index error)');
-			core.endGroup();
+			error('Internal error! Unable to parse available GPG ciphers! (array index error)');
 			return false;
 		}
 

--- a/packages/e2e-tests/src/GPG.ts
+++ b/packages/e2e-tests/src/GPG.ts
@@ -4,6 +4,7 @@ import zxcvbn from 'zxcvbn';
 import child_process, { type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
 import fs from 'node:fs';
 
+// LATER: refactor to use SpawnSync.ts for improved error handling
 class GPG {
 	constructor(private readonly inputs: InputFactory) {}
 

--- a/packages/e2e-tests/src/Git.ts
+++ b/packages/e2e-tests/src/Git.ts
@@ -7,7 +7,7 @@ class Git {
 	private readonly spawnSync: SpawnSync;
 	private readonly cache: Cache;
 
-	constructor(private readonly repo: Repository) {
+	constructor(public readonly repo: Repository) {
 		this.spawnSync = new SpawnSync(repo.cwd);
 		this.cache = new Cache(repo);
 	}
@@ -66,6 +66,8 @@ class Git {
 			);
 			throw new Error();
 		}
+
+		this.repo.commit = sha;
 
 		return sha;
 	}

--- a/packages/e2e-tests/src/Git.ts
+++ b/packages/e2e-tests/src/Git.ts
@@ -1,7 +1,7 @@
 import { Cache } from './Cache';
 import { SpawnSync } from './SpawnSync';
 import { Repository } from './Repository';
-import { log, error, notice } from './utilities';
+import { log, error, annotation } from './utilities';
 
 class Git {
 	private readonly spawnSync: SpawnSync;
@@ -61,7 +61,7 @@ class Git {
 				'Remote refs: ' + git.stdout,
 				'Commit sha: ' + sha
 			);
-			notice(
+			annotation(
 				'Failed to obtain the latest git commit sha for the given repository and branch! (click for more details)'
 			);
 			throw new Error();

--- a/packages/e2e-tests/src/Git.ts
+++ b/packages/e2e-tests/src/Git.ts
@@ -61,9 +61,10 @@ class Git {
 				'Remote refs: ' + git.stdout,
 				'Commit sha: ' + sha
 			);
-			const message = 'Failed to obtain the latest git  commit sha for the given repository and branch!';
-			notice(message + ' (click for more details)');
-			throw new Error(message);
+			notice(
+				'Failed to obtain the latest git commit sha for the given repository and branch! (click for more details)'
+			);
+			throw new Error();
 		}
 
 		return sha;

--- a/packages/e2e-tests/src/Git.ts
+++ b/packages/e2e-tests/src/Git.ts
@@ -1,6 +1,7 @@
 import { Cache } from './Cache';
 import { SpawnSync } from './SpawnSync';
 import { Repository } from './Repository';
+import { log } from './utilities';
 import * as core from '@actions/core';
 
 class Git {
@@ -30,10 +31,10 @@ class Git {
 			return this.cache.restore(key, [this.repo.cwd]);
 		};
 		if (await cloneFromCache()) {
-			core.info(`Found git repository '${this.repo.name}' in cache`);
+			log(`Found git repository '${this.repo.name}' in cache`);
 			return this;
 		}
-		core.notice(`Did not find git repository '${this.repo.name}' in cache, cloning from remote`);
+		log(`Did not find git repository '${this.repo.name}' in cache, cloning from remote`);
 		cloneFromRemote();
 		await this.cache.save(key, [this.repo.cwd]);
 		return this;

--- a/packages/e2e-tests/src/Git.ts
+++ b/packages/e2e-tests/src/Git.ts
@@ -1,8 +1,7 @@
 import { Cache } from './Cache';
 import { SpawnSync } from './SpawnSync';
 import { Repository } from './Repository';
-import { log } from './utilities';
-import * as core from '@actions/core';
+import { log, error, notice } from './utilities';
 
 class Git {
 	private readonly spawnSync: SpawnSync;
@@ -55,9 +54,16 @@ class Git {
 		const sha = cut.stdout;
 
 		if (!sha || sha.length === 0) {
-			core.setFailed(
-				`Failed to obtain latest commit sha for repository '${this.repo.name}' for branch '${this.repo.branch}' \ngit refs: \n${git.stdout} \ncut outcome: ${sha}`
+			error(
+				'Details of the git parameters:',
+				'Repository: ' + this.repo.name,
+				'Branch: ' + this.repo.branch,
+				'Remote refs: ' + git.stdout,
+				'Commit sha: ' + sha
 			);
+			const message = 'Failed to obtain the latest git  commit sha for the given repository and branch!';
+			notice(message + ' (click for more details)');
+			throw new Error(message);
 		}
 
 		return sha;

--- a/packages/e2e-tests/src/Repository.ts
+++ b/packages/e2e-tests/src/Repository.ts
@@ -1,4 +1,4 @@
-import { error, notice } from './utilities';
+import { error, annotation } from './utilities';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as Path from 'node:path';
@@ -34,7 +34,7 @@ class Repository {
 	private checkPathAvailable(path: string): void {
 		if (fs.existsSync(path)) {
 			error(`Cannot perform 'git clone' as the destination path already exists!`, 'Path: ' + path);
-			notice('Cannot clone repository! (click for more details)');
+			annotation('Cannot clone repository! (click for more details)');
 			throw new Error();
 		}
 	}

--- a/packages/e2e-tests/src/Repository.ts
+++ b/packages/e2e-tests/src/Repository.ts
@@ -14,6 +14,15 @@ class Repository {
 	public readonly branch: string;
 	public readonly cwd: string;
 	public readonly remote: string;
+	private _commit = '❌';
+
+	set commit(sha: string) {
+		this._commit = sha;
+	}
+
+	get commit(): string {
+		return this._commit;
+	}
 
 	constructor(params: Parameters) {
 		const name = this.sanitizeName(params.name);

--- a/packages/e2e-tests/src/Repository.ts
+++ b/packages/e2e-tests/src/Repository.ts
@@ -1,7 +1,7 @@
-import * as os from 'os';
-import * as fs from 'fs';
-import * as Path from 'path';
-import * as core from '@actions/core';
+import { error, notice } from './utilities';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as Path from 'node:path';
 
 type Parameters = {
 	name: string;
@@ -33,7 +33,9 @@ class Repository {
 
 	private checkPathAvailable(path: string): void {
 		if (fs.existsSync(path)) {
-			core.setFailed(`Given path already exists: \n${path}`);
+			error(`Cannot perform 'git clone' as the destination path already exists!`, 'Path: ' + path);
+			notice('Cannot clone repository! (click for more details)');
+			throw new Error();
 		}
 	}
 

--- a/packages/e2e-tests/src/Tar.ts
+++ b/packages/e2e-tests/src/Tar.ts
@@ -43,7 +43,7 @@ class Tar {
 			encoding: 'utf-8',
 		});
 
-		log(command.stdout);
+		log('Successfully created tarball:', command.stdout);
 
 		if (command.status !== 0) {
 			errorForSpawnSync(command, 'Could not create tarball!');
@@ -116,7 +116,7 @@ class Tar {
 		);
 
 		if (command.status === 0) {
-			log(command.stdout);
+			log('Successfully extracted tarball files:', command.stdout);
 		}
 
 		if (command.status !== 0) {

--- a/packages/e2e-tests/src/Tar.ts
+++ b/packages/e2e-tests/src/Tar.ts
@@ -2,6 +2,7 @@ import { absPath, command, cwd, log, error, errorForSpawnSync } from './utilitie
 import child_process from 'node:child_process';
 import fs from 'node:fs';
 
+// LATER: refactor to use SpawnSync.ts for improved error handling
 class Tar {
 	private isInstalled(): boolean {
 		return command('tar');

--- a/packages/e2e-tests/src/Yarn.ts
+++ b/packages/e2e-tests/src/Yarn.ts
@@ -6,6 +6,7 @@ import { Artifact } from './Artifact';
 import { Tar } from './Tar';
 import { GPG } from './GPG';
 import { error, log } from './utilities';
+import * as core from '@actions/core';
 import * as glob from '@actions/glob';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -58,6 +59,8 @@ class Yarn {
 
 		const buffer = this.spawnSync.call('yarn', ['playwright', 'test', `--output=${resultsPath}`], {
 			env,
+			noAnnotation: true,
+			noException: true,
 		});
 
 		// if docker cache will become available, save should be called here
@@ -65,6 +68,7 @@ class Yarn {
 		if (buffer.status !== 0) {
 			await this.saveHtmlReport(htmlReportPath);
 			await this.saveTestResults(resultsPath);
+			core.setFailed('End-to-end tests did not pass successfully!');
 		}
 
 		return this;

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -23,9 +23,9 @@ export function command(binary: string): boolean {
 }
 
 /**
- * Create GitHub notice for the return of spawnSync() function
+ * Create GitHub annotation for the return of spawnSync() function
  */
-export function noticeForSpawnSync({
+export function annotationForSpawnSync({
 	command,
 	group,
 	message,
@@ -56,10 +56,10 @@ type NoticeType = keyof Pick<typeof core, 'notice' | 'info' | 'warning' | 'error
 type NoticeOptions = { type?: NoticeType; group?: string };
 
 /**
- * Create a GitHub notice
+ * Create a GitHub annotation
  * @link https://github.com/actions/toolkit/tree/main/packages/core#logging
  */
-export function notice(message: string | string[], options: NoticeOptions = { type: 'error' }): void {
+export function annotation(message: string | string[], options: NoticeOptions = { type: 'error' }): void {
 	const type = options.type ?? 'error';
 	const group = options.group;
 	if (group) {

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -10,6 +10,7 @@ import child_process, { type SpawnSyncReturns, type SpawnSyncOptionsWithStringEn
  * @param group GitHub notice group (optional)
  * @returns
  */
+// LATER: refactor to use SpawnSync.ts for improved error handling
 export function command(binary: string): boolean {
 	const bin = 'command';
 	const args = ['-v', binary] as const;

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -22,35 +22,6 @@ export function command(binary: string): boolean {
 	return true;
 }
 
-/**
- * Create GitHub annotation for the return of spawnSync() function
- */
-export function annotationForSpawnSync({
-	command,
-	group,
-	message,
-}: {
-	group?: string;
-	message?: string;
-	command: SpawnSyncReturns<string | Buffer>;
-}): void {
-	if (group) {
-		core.startGroup(group);
-	}
-	if (message) {
-		core.error(message);
-	}
-	core.error('Stderr: ' + command.stderr);
-	core.error('Signal: ' + command.signal);
-	core.error('Status: ' + command.status);
-	if (command.error) {
-		core.error('Error: ' + command.error.message);
-	}
-	if (group) {
-		core.endGroup();
-	}
-}
-
 type NoticeType = keyof Pick<typeof core, 'notice' | 'info' | 'warning' | 'error' | 'debug'>;
 
 type NoticeOptions = { type?: NoticeType; group?: string };

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -99,15 +99,37 @@ export function warn(...message: string[]): void {
 }
 
 /**
+ * Make sure stderr is always a string as it could be null
+ * @link https://nodejs.org/docs/latest-v16.x/api/child_process.html#subprocessstderr
+ */
+function stderrToString(stderr: SpawnSyncReturns<string | Buffer>['stderr']): string {
+	if (!stderr) {
+		return '';
+	}
+	return stderr.toString();
+}
+
+/**
+ * Make sure stdout is always a string as it could be null
+ * @link https://nodejs.org/docs/latest-v16.x/api/child_process.html#subprocessstdout
+ */
+function stdoutToString(stdout: SpawnSyncReturns<string | Buffer>['stdout']): string {
+	if (!stdout) {
+		return '';
+	}
+	return stdout.toString();
+}
+
+/**
  * Convert output of command() function to a log message (single string)
  */
 function spawnSyncToString(spawnSync: SpawnSyncReturns<string | Buffer>): string {
 	const array: string[] = [];
-	const stderr = spawnSync.stderr.toString();
+	const stderr = stderrToString(spawnSync.stderr);
 	if (stderr.length) {
 		array.push('Stderr: ' + spawnSync.stderr.toString());
 	}
-	const stdout = spawnSync.stdout.toString();
+	const stdout = stdoutToString(spawnSync.stdout);
 	if (stdout.length) {
 		array.push('Stdout: ' + stdout);
 	}

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -108,6 +108,9 @@ export function error(...message: string[]): void {
 	_log(message, 'error');
 }
 
+/**
+ * Alias for log()
+ */
 export function info(...message: string[]): void {
 	_log(message, 'info');
 }
@@ -116,6 +119,9 @@ export function log(...message: string[]): void {
 	_log(message, 'log');
 }
 
+/**
+ * Alias for error()
+ */
 export function warn(...message: string[]): void {
 	_log(message, 'warn');
 }
@@ -149,6 +155,9 @@ export function errorForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, 
 	error(string(message), commandToString(spawnSync));
 }
 
+/**
+ * Alias for logForSpawnSync()
+ */
 export function infoForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, ...message: string[]): void {
 	info(string(message), commandToString(spawnSync));
 }
@@ -157,6 +166,9 @@ export function logForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, ..
 	log(string(message), commandToString(spawnSync));
 }
 
+/**
+ * Alias for errorForSpawnSync()
+ */
 export function warnForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, message: string[]): void {
 	warn(string(message), commandToString(spawnSync));
 }

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -3,19 +3,20 @@ import process from 'node:process';
 import * as core from '@actions/core';
 import child_process, { type SpawnSyncReturns, type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
 
-export function command(binary: string, group?: string): boolean {
+/**
+ * Check if the given binary is installed
+ * @link https://askubuntu.com/questions/512770/what-is-the-bash-command-command
+ * @param binary Absolute path to a binary file
+ * @param group GitHub notice group (optional)
+ * @returns
+ */
+export function command(binary: string): boolean {
 	const bin = 'command';
 	const args = ['-v', binary] as const;
 	const options: SpawnSyncOptionsWithStringEncoding = { stdio: 'pipe', encoding: 'utf-8', shell: true };
 	const command = child_process.spawnSync(bin, args, options);
 	if (command.status !== 0) {
-		if (group) {
-			core.startGroup(group);
-		}
-		core.error(`Did not find installed binary for '${binary}'!`);
-		if (group) {
-			core.endGroup();
-		}
+		error(`Did not find installed binary for '${binary}'!`);
 		return false;
 	}
 	return true;

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -100,46 +100,46 @@ export function warn(...message: string[]): void {
 /**
  * Convert output of command() function to a log message (single string)
  */
-function commandToString(command: SpawnSyncReturns<string | Buffer>): string {
+function spawnSyncToString(spawnSync: SpawnSyncReturns<string | Buffer>): string {
 	const array: string[] = [];
-	const stderr = command.stderr.toString();
+	const stderr = spawnSync.stderr.toString();
 	if (stderr.length) {
-		array.push('Stderr: ' + command.stderr.toString());
+		array.push('Stderr: ' + spawnSync.stderr.toString());
 	}
-	const stdout = command.stdout.toString();
+	const stdout = spawnSync.stdout.toString();
 	if (stdout.length) {
 		array.push('Stdout: ' + stdout);
 	}
-	if (command.error) {
-		array.push(command.error.name + ': ' + command.error.message);
+	if (spawnSync.error) {
+		array.push(spawnSync.error.name + ': ' + spawnSync.error.message);
 	}
-	if (command.signal) {
-		array.push('Signal used to kill the subprocess: ' + command.signal.toString());
+	if (spawnSync.signal) {
+		array.push('Signal used to kill the subprocess: ' + spawnSync.signal.toString());
 	}
-	if (command.status) {
-		array.push('Exit code of the subprocess: ' + command.status.toString());
+	if (spawnSync.status) {
+		array.push('Exit code of the subprocess: ' + spawnSync.status.toString());
 	}
 	return string(array);
 }
 
 export function errorForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, ...message: string[]): void {
-	error(string(message), commandToString(spawnSync));
+	error(string(message), spawnSyncToString(spawnSync));
 }
 
 /**
  * Alias for logForSpawnSync()
  */
 export function infoForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, ...message: string[]): void {
-	info(string(message), commandToString(spawnSync));
+	info(string(message), spawnSyncToString(spawnSync));
 }
 
 export function logForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, ...message: string[]): void {
-	log(string(message), commandToString(spawnSync));
+	log(string(message), spawnSyncToString(spawnSync));
 }
 
 /**
  * Alias for errorForSpawnSync()
  */
 export function warnForSpawnSync(spawnSync: SpawnSyncReturns<string | Buffer>, message: string[]): void {
-	warn(string(message), commandToString(spawnSync));
+	warn(string(message), spawnSyncToString(spawnSync));
 }

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -23,15 +23,15 @@ export function command(binary: string): boolean {
 	return true;
 }
 
-type NoticeType = keyof Pick<typeof core, 'notice' | 'info' | 'warning' | 'error' | 'debug'>;
+type AnnotationType = keyof Pick<typeof core, 'notice' | 'info' | 'warning' | 'error' | 'debug'>;
 
-type NoticeOptions = { type?: NoticeType; group?: string };
+type AnnotationOptions = { type?: AnnotationType; group?: string };
 
 /**
  * Create a GitHub annotation
  * @link https://github.com/actions/toolkit/tree/main/packages/core#logging
  */
-export function annotation(message: string | string[], options: NoticeOptions = { type: 'error' }): void {
+export function annotation(message: string | string[], options: AnnotationOptions = { type: 'error' }): void {
 	const type = options.type ?? 'error';
 	const group = options.group;
 	if (group) {

--- a/packages/e2e-tests/src/utilities.ts
+++ b/packages/e2e-tests/src/utilities.ts
@@ -23,9 +23,9 @@ export function command(binary: string): boolean {
 }
 
 /**
- * Create GitHub notice for the return of command() function
+ * Create GitHub notice for the return of spawnSync() function
  */
-export function noticeForCommand({
+export function noticeForSpawnSync({
 	command,
 	group,
 	message,


### PR DESCRIPTION
Improve logging for GitHub CI. Example of new logging format:

- https://github.com/eventespresso/test-workflow/actions/runs/7930541082
- https://github.com/eventespresso/test-workflow/actions/runs/7930695490

Summary of changes:

- add git-related information to the job summary
- reduce the number of [annotations](https://github.com/actions/toolkit/tree/main/packages/core#annotations) to keep "noise" level to minimum