### PR TITLE
Fix stale apt repository index in e2e package

### DIFF
--- a/packages/e2e-tests/src/Action.ts
+++ b/packages/e2e-tests/src/Action.ts
@@ -38,6 +38,7 @@ class Action {
 		await e2e.yarn.install({ frozenLockfile: true });
 
 		// install dependencies
+		this.updateAptRepoIndex();
 		this.mkcert();
 		this.ddev();
 		this.browsers.install(e2e);
@@ -65,6 +66,15 @@ class Action {
 			}),
 		]);
 		await core.summary.write();
+	}
+
+	/**
+	 * @link [reference](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners)
+	 * @link [GitHub issue #61](https://github.com/eventespresso/actions/issues/61)
+	 */
+	private updateAptRepoIndex(): void {
+		log('Updating apt repository index...');
+		this.spawnSync.call('sudo', ['apt-get', 'update']);
 	}
 
 	private mkcert(): void {


### PR DESCRIPTION
Fix #61 

Successful test - https://github.com/eventespresso/test-workflow/actions/runs/8668697491 (cancelled b/c no need to run the entire suite of tests)